### PR TITLE
Stage 1: fix test plumbing (make target, env-var handling, hardcoded DNS answer)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,15 @@
 #     make test KLEENED_MINIMAL_TESTJAIL=/path/to/minimal_testjail.txz
 KLEENED_MINIMAL_TESTJAIL ?= $(HOME)/kleened/test/data/minimal_testjail.txz
 
-# The tests need root (jails, ZFS, the daemon socket), but 'poetry run sudo pytest'
-# does not do what it looks like: sudo resets PATH via secure_path, so the pytest
-# that actually runs is root's system pytest rather than the locked venv one.
-# Resolve the venv's pytest and hand sudo the absolute path.
+# The tests need root: jails, ZFS and the daemon socket.
 #
-# NB: the substitution happens in the *recipe*, not via GNU make's $(shell ...) --
-# FreeBSD's make is bmake, which has no such function. '$$' survives both.
+# sudo is given the venv's pytest by absolute path, because it resets PATH via
+# secure_path and would otherwise pick up root's system pytest instead of the
+# locked one. The path is resolved in the recipe rather than with GNU make's
+# $(shell ...): FreeBSD's make is bmake, which has no such function.
 #
 # 'sudo env VAR=...' rather than 'sudo -E': -E depends on the sudoers SETENV
-# privilege and still leaves PATH subject to secure_path. Being explicit about the
-# one variable the suite needs is predictable everywhere.
+# privilege and still leaves PATH subject to secure_path.
 test:
 	sudo env KLEENED_MINIMAL_TESTJAIL="$(KLEENED_MINIMAL_TESTJAIL)" \
 	    "$$(poetry env info --path)/bin/pytest" -x -vv

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,22 @@
+# Path to kleened's minimal test-jail tarball. Override on the command line if your
+# kleened checkout lives elsewhere:
+#     make test KLEENED_MINIMAL_TESTJAIL=/path/to/minimal_testjail.txz
+KLEENED_MINIMAL_TESTJAIL ?= $(HOME)/kleened/test/data/minimal_testjail.txz
+
+# The tests need root (jails, ZFS, the daemon socket), but 'poetry run sudo pytest'
+# does not do what it looks like: sudo resets PATH via secure_path, so the pytest
+# that actually runs is root's system pytest rather than the locked venv one.
+# Resolve the venv's pytest and hand sudo the absolute path.
+#
+# NB: the substitution happens in the *recipe*, not via GNU make's $(shell ...) --
+# FreeBSD's make is bmake, which has no such function. '$$' survives both.
+#
+# 'sudo env VAR=...' rather than 'sudo -E': -E depends on the sudoers SETENV
+# privilege and still leaves PATH subject to secure_path. Being explicit about the
+# one variable the suite needs is predictable everywhere.
 test:
-	poetry run sudo -E pytest -x -vv
+	sudo env KLEENED_MINIMAL_TESTJAIL="$(KLEENED_MINIMAL_TESTJAIL)" \
+	    "$$(poetry env info --path)/bin/pytest" -x -vv
 
 docs:
 	poetry run python scripts/generate_yaml_docs.py /vagrant/kleene-docs/_data/klee-reference

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -19,11 +19,9 @@ instructions = ["FROM FreeBSD", 'RUN echo "lol" > /root/test.txt', "CMD /usr/bin
 
 cwd = os.getcwd()
 
-# Fail fast and loudly. Previously this defaulted to None, which silently produced
-# a 'file://None' URL and surfaced as 'could not fetch file from url' or a TypeError
-# deep inside a test -- several hours of head-scratching away from the real cause.
-# NB: 'sudo' strips the environment unless it is passed through explicitly; see the
-# 'test' target in the Makefile.
+# Required, and checked at import time so a missing value fails here rather than
+# as a confusing error deep inside a test. NB: 'sudo' strips the environment unless
+# it is passed through explicitly; see the 'test' target in the Makefile.
 KLEENED_MINIMAL_TESTJAIL = os.getenv("KLEENED_MINIMAL_TESTJAIL")
 if KLEENED_MINIMAL_TESTJAIL is None:
     raise RuntimeError(

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -18,7 +18,18 @@ from testutils import (
 instructions = ["FROM FreeBSD", 'RUN echo "lol" > /root/test.txt', "CMD /usr/bin/uname"]
 
 cwd = os.getcwd()
-KLEENED_MINIMAL_TESTJAIL = os.getenv("KLEENED_MINIMAL_TESTJAIL", default=None)
+
+# Fail fast and loudly. Previously this defaulted to None, which silently produced
+# a 'file://None' URL and surfaced as 'could not fetch file from url' or a TypeError
+# deep inside a test -- several hours of head-scratching away from the real cause.
+# NB: 'sudo' strips the environment unless it is passed through explicitly; see the
+# 'test' target in the Makefile.
+KLEENED_MINIMAL_TESTJAIL = os.getenv("KLEENED_MINIMAL_TESTJAIL")
+if KLEENED_MINIMAL_TESTJAIL is None:
+    raise RuntimeError(
+        "KLEENED_MINIMAL_TESTJAIL is not set. It must point at the minimal test-jail "
+        "tarball, e.g. /path/to/kleened/test/data/minimal_testjail.txz"
+    )
 
 
 class TestImageCommand:
@@ -172,7 +183,6 @@ class TestImageCommand:
         for n, nametag in enumerate(
             ["WithSnapshots", "WithSnapshots:latest", image["id"]]
         ):
-            print("using namtag: ", nametag)
             dockerfile = dockerfile_from_str(
                 f"""
                FROM {nametag}{snapshot}

--- a/test/network_test.py
+++ b/test/network_test.py
@@ -1,5 +1,6 @@
 import time
 import json
+import re
 
 from testutils import (
     container_get_netstat_info,
@@ -228,36 +229,34 @@ def container_is_connected(container_id, driver="loopback"):
     output = run(f"container start {container_id}")
     exec_id = extract_exec_id(output)
     if driver == "loopback":
-        connected_output = [
-            f"created execution instance {exec_id}",
-            "Using domain server:",
-            "Name: 1.1.1.1",
-            "Address: 1.1.1.1#53",
-            "Aliases: ",
-            "",
-            "freebsd.org has address 96.47.72.84",
-            "",
-            container_stopped_msg(exec_id),
-            "",
-        ]
+        expected_prefix = [f"created execution instance {exec_id}"]
     elif driver == "vnet":
-        connected_output = [
+        expected_prefix = [
             f"created execution instance {exec_id}",
             "add net default: gateway 10.13.37.1",
-            "Using domain server:",
-            "Name: 1.1.1.1",
-            "Address: 1.1.1.1#53",
-            "Aliases: ",
-            "",
-            "freebsd.org has address 96.47.72.84",
-            "",
-            container_stopped_msg(exec_id),
-            "",
         ]
     else:
-        connected_output = ["unknown driver used"]
+        raise AssertionError(f"unknown driver used: {driver}")
 
-    assert output == connected_output
+    assert output[: len(expected_prefix)] == expected_prefix
+    assert output[len(expected_prefix) : len(expected_prefix) + 5] == [
+        "Using domain server:",
+        "Name: 1.1.1.1",
+        "Address: 1.1.1.1#53",
+        "Aliases: ",
+        "",
+    ]
+    # Assert the *shape* of the answer rather than freebsd.org's current A record,
+    # which changes independently of Kleene.
+    assert re.fullmatch(
+        r"freebsd\.org has address \d{1,3}(\.\d{1,3}){3}",
+        output[len(expected_prefix) + 5],
+    )
+    assert output[len(expected_prefix) + 6 :] == [
+        "",
+        container_stopped_msg(exec_id),
+        "",
+    ]
 
 
 def container_is_disconnected(container_id):

--- a/test/root_test.py
+++ b/test/root_test.py
@@ -32,7 +32,6 @@ def remove_all_configs():
         try:
             os.remove(os.path.expanduser(filepath))
         except FileNotFoundError:
-            print("Did not exist")
             continue
 
 

--- a/test/testutils.py
+++ b/test/testutils.py
@@ -114,21 +114,6 @@ def decode_valid_image_build(result):
     return image_id, build_log
 
 
-def remove_all_images():
-    _header, _lines, *images = run("image ls")
-    image_ids = []
-    for line in images[:-1]:
-        image_id, name, tag, *_rest = line.split(" ")
-        if image_id == "":
-            continue
-        if name == "FreeBSD" and tag == "latest":
-            continue
-        image_ids.append(image_id)
-
-    if len(image_ids) != 0:
-        run("image rm " + " ".join(image_ids))
-
-
 def create_container(
     image="FreeBSD:latest",
     name=None,
@@ -207,10 +192,6 @@ def list_containers(all_=True):
         **kwargs,
     )
     return response.parsed
-
-
-def container_netstat(container_id):
-    return run(f"container exec {container_id} /usr/bin/netstat --libxo json -i -4")
 
 
 def container_get_netstat_info(container_id, driver):


### PR DESCRIPTION
No change in pass/fail count — 93 passed / 8 failed both before and after, and those 8 have unrelated causes (see [kleene-dev#1](https://github.com/kleene-project/kleene-dev/pull/1)). What changes is that several things which made the suite hard to *run* and hard to *debug* are fixed.

Part of the testing refactor; companion to [kleened#9](https://github.com/kleene-project/kleened/pull/9).

## `make test` wasn't running the venv's pytest

`poetry run sudo pytest` looks right but isn't: `sudo` resets `PATH` via `secure_path`, so the pytest that actually ran was **root's system pytest**, not the locked one from `poetry.lock`.

Now resolves the venv path and hands `sudo` an absolute path. Note the substitution happens in the *recipe*, not via GNU make's `$(shell ...)` — FreeBSD's `make` is bmake and has no such function. The first attempt at this failed with `*** Error code 127`, which is worth knowing before someone reaches for another GNU-ism here.

## `KLEENED_MINIMAL_TESTJAIL` failed silently

`image_test.py` read it with a `None` default. `sudo` strips the environment, so it became `None`, the URL became `file://None`, and four tests failed with `could not fetch file from url` or a `TypeError` raised deep inside a test — a long way from the actual cause. It cost real time to track down during the baseline run.

It now raises immediately with a message naming the variable, and the make target passes it through explicitly. `sudo env VAR=...` rather than `-E`, since `-E` depends on the sudoers `SETENV` privilege and still leaves `PATH` subject to `secure_path`.

Confirmed: with the variable set, all four of those tests pass.

## Hardcoded DNS answer

`network_test.py` asserted freebsd.org's literal A record (`96.47.72.84`) twice, inside a whole-list equality check — so the test would fail the day freebsd.org changes DNS, for reasons having nothing to do with Kleene. `container_is_connected()` now asserts the surrounding lines exactly and the answer line by shape.

## Also

- Removed two dead helpers from `testutils.py` (`remove_all_images`, `container_netstat`).
- Removed two leftover debug prints.

## Verification

Full suite in the dev VM: 101 tests, 93 passed, 8 failed, 45 s — same set as baseline, no regressions. `make test` now runs the correct interpreter end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)